### PR TITLE
Fixing an issue where if the argument has multiple quoted parameters, th...

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -157,7 +157,7 @@ module Mixlib
       IS_BATCH_FILE = /\.bat|\.cmd$/i
 
       def command_to_run
-        if command =~ /^\s*"(.*)"/
+        if command =~ /^\s*"(.*?)"/
           # If we have quotes, do an exact match
           candidate = $1
         else


### PR DESCRIPTION
...e command will not be extracted properly.

I'm pretty sure this is causing some very annoying behavior with Chef's execute on Windows.
