### PR TITLE
CHEF-2517 Set default HOME environment variable

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -76,10 +76,6 @@ module Mixlib
     # The umask that will be set for the subcommand.
     attr_reader :umask
 
-    # Environment variables that will be set for the subcommand. Refer to the
-    # documentation of new to understand how ShellOut interprets this.
-    attr_reader :environment
-
     # The maximum time this command is allowed to run. Usually set via options
     # to new
     attr_writer :timeout
@@ -177,6 +173,18 @@ module Mixlib
     def gid
       return nil unless group
       group.kind_of?(Integer) ? group : Etc.getgrnam(group.to_s).gid
+    end
+
+    # Environment variables that will be set for the subcommand. Refer to the
+    # documentation of new to understand how ShellOut interprets this.
+    def environment
+      return @environment if @environment.empty? || !uid
+
+      unless @environment.has_key?('HOME')
+        pwuid = Etc.getpwuid(uid)
+        @environment['HOME'] ||= pwuid.dir if pwuid
+      end
+      @environment
     end
 
     def timeout


### PR DESCRIPTION
When changing the user, on UNIX systems, the `$HOME` of the originating user was kept by default which leads to unexpected results when relying on the correct variable in executed scripts.

Unless the HOME is overridden, we now set it to the HOME of the target user, if this information can be retrieved from the `/etc/passwd` file.

This fixes http://tickets.opscode.com/browse/CHEF-2517
