### PR TITLE
[MIXLIB-6] Fix test due to /bin being a symlink on Fedora.

### DIFF
--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -344,6 +344,8 @@ describe Mixlib::ShellOut do
       let(:options) { { :cwd => cwd } }
 
       context 'when running under Unix', :unix_only do
+        # Use /bin for tests only if it is not a symlink. Some
+        # distributions (e.g. Fedora) symlink it to /usr/bin
         let(:cwd) { File.symlink?('/bin') ? '/tmp' : '/bin' }
         let(:cmd) { 'pwd' }
 


### PR DESCRIPTION
Use /tmp instead for this test.

/bin, /sbin etc. were all moved to /usr under Fedora 17 and symlinks were created. See http://fedoraproject.org/wiki/Features/UsrMove
