### PR TITLE
Add User Impersonation

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -42,6 +42,7 @@ module Mixlib
     attr_accessor :domain
     attr_accessor :password
     attr_accessor :with_logon
+    attr_accessor :remote_call
 
     # Group the command will run as. Normally set via options passed to new
     attr_accessor :group
@@ -271,6 +272,8 @@ module Mixlib
         when 'user'
           self.user = setting
           self.with_logon = setting
+        when 'remote_call'
+          self.remote_call = setting
         when 'group'
           self.group = setting
         when 'umask'

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -69,6 +69,7 @@ module Mixlib
           create_process_args[:domain] = domain if domain
           create_process_args[:with_logon] = with_logon if with_logon
           create_process_args[:password] = password if password
+          create_process_args[:remote_call] = remote_call if remote_call
 
           #
           # Start the process

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -70,7 +70,7 @@ module Process
     valid_keys = %w/
       app_name command_line inherit creation_flags cwd environment
       startup_info thread_inherit process_inherit close_handles with_logon
-      domain password logon_with_profile
+      domain password remote_call
     /
 
     valid_si_keys = %/
@@ -86,7 +86,7 @@ module Process
     }
 
     #See if running as local service
-    is_local_service = ENV["USERNAME"].downcase == "local service"
+    is_local_service = ENV["USERNAME"].downcase == "local service" 
 
     # Validate the keys, and convert symbols and case to lowercase strings.
     args.each{ |key, val|
@@ -132,7 +132,7 @@ module Process
       # The argument format is a series of null-terminated strings, with an additional null terminator.
       # If calling CreateProcessWithLogonW must put the hash in a wide format
       env = env.map do |e|
-        hash['with_logon'].nil? || is_local_service ? e + "\0" : multi_to_wide(e)
+        hash['with_logon'].nil? || is_local_service || hash['remote_call'] ? e + "\0" : multi_to_wide(e)
       end.join("") + "\0"
 
       env = [env].pack('p*').unpack('L').first
@@ -212,7 +212,7 @@ module Process
 
     if hash['with_logon']
       # Need to do a LogonUser and CreateProcessAsUser to work on all windows platforms
-      if is_local_service
+      if is_local_service || hash['remote_call']
         include Process::Constants
         extend Process::Functions
 


### PR DESCRIPTION
Added the ability to, on shell_out, switch to a different user before creating the process.  There are three scenarios covered:

1) Chef is run as a local user.  This calls the CreateProcessWithLogonW Win32 API function
2) Chef is run as local service, the case where chef is installed as a service or as a scheduled task.  This calls the LogonUser and CreateProcessAsUser Win32 API functions.  These functions require a special OS permission of "Replace a process level token" which local service has by default.  CreateProcessWithLogonW can not be used as this does not work cross version.
3) Chef is run remotely (vagrant, winrm, psexec, etc).  There is a monkey patch switch to pass called "remote_call" that will force the use of API functions in the second scenario, but requires that the use set the "Replace a process level token" permission on the account that is remotely calling chef.  This is because using CreateProcessWithLogonW is causing a permissions error on the windows station and desktop access.  There should be a feature enhancement down the road to fix this.

The monkey patch is a bit annoying, but after spending some time digging in to setting the permissions on the windows station and desktop, this is a VERY non-trivial thing to do and it is a limited use case.
