### PR TITLE
add a success? and failure? method on command

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -233,9 +233,17 @@ module Mixlib
     # === Raises
     # ::ShellCommandFailed::: via +invalid!+
     def error!
-      unless Array(valid_exit_codes).include?(exitstatus)
+      if failure?
         invalid!("Expected process to exit with #{valid_exit_codes.inspect}, but received '#{exitstatus}'")
       end
+    end
+
+    def success?
+      Array(valid_exit_codes).include?(exitstatus)
+    end
+
+    def failure?
+      !success?
     end
 
     # Raises a ShellCommandFailed exception, appending the

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -648,6 +648,14 @@ describe Mixlib::ShellOut do
         it "should set the exit status of the command" do
           exit_status.should eql(exit_code)
         end
+
+        it "should be successful" do
+          executed_cmd.should     be_success
+        end
+
+        it "should not be failure" do
+          executed_cmd.should_not be_failure
+        end
       end
 
       context 'with nonzero exit status' do
@@ -669,6 +677,14 @@ describe Mixlib::ShellOut do
         it "should set the exit status of the command" do
           exit_status.should eql(exit_code)
         end
+
+        it "should be a failure" do
+          executed_cmd.should be_failure
+        end
+
+        it "should not be successful" do
+          executed_cmd.should_not be_success
+        end
       end
 
       context 'with valid exit codes' do
@@ -686,6 +702,14 @@ describe Mixlib::ShellOut do
           it "should set the exit status of the command" do
             exit_status.should eql(exit_code)
           end
+
+          it "should be successful" do
+            executed_cmd.should     be_success
+          end
+
+          it "should not be failure" do
+            executed_cmd.should_not be_failure
+          end
         end
 
         context 'when exiting with invalid code' do
@@ -700,6 +724,14 @@ describe Mixlib::ShellOut do
             exit_status.should eql(exit_code)
           end
 
+          it "should be a failure" do
+            executed_cmd.should be_failure
+          end
+
+          it "should not be successful" do
+            executed_cmd.should_not be_success
+          end
+
           context 'with input data' do
             let(:options) { { :returns => valid_exit_codes, :input => input } }
             let(:input) { "Random data #{rand(1000000)}" }
@@ -710,6 +742,14 @@ describe Mixlib::ShellOut do
 
             it "should set the exit status of the command" do
               exit_status.should eql(exit_code)
+            end
+
+            it "should be a failure" do
+              executed_cmd.should be_failure
+            end
+
+            it "should not be successful" do
+              executed_cmd.should_not be_success
             end
           end
         end
@@ -724,6 +764,14 @@ describe Mixlib::ShellOut do
 
           it "should set the exit status of the command" do
             exit_status.should eql(exit_code)
+          end
+
+          it "should be a failure" do
+            executed_cmd.should be_failure
+          end
+
+          it "should not be successful" do
+            executed_cmd.should_not be_success
           end
         end
       end


### PR DESCRIPTION
This allows one to use an api like:

``` ruby
cmd = Mixlib::ShellOut.new('true')
cmd.success? #=> true
cmd.failure? #=> false

cmd = Mixlib::ShellOut.new('false')
cmd.success? #=> false
cmd.failure? #=> true

```
