### PR TITLE
Add missing windows test dependency windows-pr

### DIFF
--- a/mixlib-shellout.gemspec
+++ b/mixlib-shellout.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
 
   %w(rspec ap).each { |gem| s.add_development_dependency gem }
+  s.add_development_dependency "windows-pr" if ENV['OS'] == 'Windows_NT'
 
   s.bindir       = "bin"
   s.executables  = []


### PR DESCRIPTION
mixlib shellout tests are failing on Windows -- they can't even run because a require for "windows/handle" can't be loaded. This is solved through including the windows-pr gem as a developer dependency. This gem is normally included in the Windows omnibus package bundled in Chef.

This break seems to have been around for a while (windows/handle has been a dependency since the beginning), and looking at the latest history for the mixlib-shellout windows Jenkins job, it has been failing for months! Not sure how I never noticed that -- I've run these tests successfully outside of Jenkins, but clearly I wasn't using bundler and the dependency was satisfied.

Note that the dependency is made conditional to only exist on Windows -- this gem seems to rely on mingw headers that are not present on other Unix environments, so it can't compile, and since the functional tests involved can't run on those environments, everything works without that dependency.

If there's a better way to do this, or if I'm misunderstanding how the dependencies and bundler are supposed to work, please let me know the right approach.
