### PR TITLE
Add missing windows dependency windows-pr for x86-mingw only

### DIFF
--- a/mixlib-shellout-x86-mingw32.gemspec
+++ b/mixlib-shellout-x86-mingw32.gemspec
@@ -4,6 +4,6 @@ gemspec = eval(IO.read(File.expand_path("../mixlib-shellout.gemspec", __FILE__))
 gemspec.platform = "x86-mingw32"
 
 gemspec.add_dependency "win32-process", "~> 0.7.0"
-gemspec.add_dependency "windows-pr"
+gemspec.add_dependency "windows-pr", "~> 1.2.2"
 
 gemspec


### PR DESCRIPTION
mixlib shellout tests are failing on Windows -- they can't even run because a require for "windows/handle" can't be loaded. This is solved through including the windows-pr gem as a developer dependency. This gem is normally included in the Windows omnibus package bundled in Chef.

This break seems to have been around for a while (windows/handle has been a dependency since the beginning), and looking at the latest history for the mixlib-shellout windows Jenkins job, it has been failing for months! Not sure how I never noticed that -- I've run these tests successfully outside of Jenkins, but clearly I wasn't using bundler and the dependency was satisfied.

Note that the dependency is made conditional to only exist on Windows by including it in an x86-mingw gemspec -- this gem seems to rely on mingw headers that are not present on other Unix environments, so it can't compile, and since the functional tests involved can't run on those environments, everything works without that dependency.

If there's a better way to do this, or if I'm misunderstanding how the dependencies and bundler are supposed to work, please let me know the right approach.
