### PR TITLE
remove Associated Press Breaking API gem dep

### DIFF
--- a/mixlib-shellout.gemspec
+++ b/mixlib-shellout.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://wiki.opscode.com/"
 
 
-  %w(rspec ap).each { |gem| s.add_development_dependency gem }
+  %w(rspec).each { |gem| s.add_development_dependency gem }
 
   s.bindir       = "bin"
   s.executables  = []


### PR DESCRIPTION
- my guess is awesome_print used to be called 'ap'?
