### PR TITLE
Run timeout tests without a subshell

### DIFF
--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -825,9 +825,16 @@ describe Mixlib::ShellOut do
         end
       end
 
-      context 'with subprocess that takes longer than timeout' do
+      context 'with subprocess that takes longer than timeout', :focus do
+        def ruby_wo_shell(code)
+          parts = %w[ruby]
+          parts << "--disable-gems" if ruby_19?
+          parts << "-e"
+          parts << code
+        end
+
         let(:cmd) do
-          ruby_eval.call(<<-CODE)
+          ruby_wo_shell(<<-CODE)
             STDOUT.sync = true
             trap(:TERM) { puts "got term"; exit!(123) }
             sleep 10
@@ -849,7 +856,7 @@ describe Mixlib::ShellOut do
 
         context "and the child is unresponsive" do
           let(:cmd) do
-            ruby_eval.call(<<-CODE)
+            ruby_wo_shell(<<-CODE)
               STDOUT.sync = true
               trap(:TERM) { puts "nanana cant hear you" }
               sleep 10


### PR DESCRIPTION
/bin/sh on Ubuntu is dash, which does not support bash's behavior of
using exec to run a command (instead of fork) when possible. This means
that, when given a single string command, instead of an array of command
plus arguments, the process created by fork/exec is dash, and the ruby
program is a child process of dash. When shellout signals the child to
exit after a timeout, it will signal dash instead of the ruby program.

To avoid this issue, the command needs to be given as an Array to avoid
creating a subshell.
