### PR TITLE
Duplicate default shellout timeout from 10mins to 20mins

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -26,7 +26,7 @@ module Mixlib
   class ShellOut
     READ_WAIT_TIME = 0.01
     READ_SIZE = 4096
-    DEFAULT_READ_TIMEOUT = 600
+    DEFAULT_READ_TIMEOUT = 1200
     DEFAULT_ENVIRONMENT = {'LC_ALL' => 'C'}
 
     if RUBY_PLATFORM =~ /mswin|mingw32|windows/
@@ -218,7 +218,7 @@ module Mixlib
     # * Errno::ENOENT  when the command is not available on the system (or not
     #   in the current $PATH)
     # * CommandTimeout  when the command does not complete
-    #   within +timeout+ seconds (default: 600s)
+    #   within +timeout+ seconds (default: 1200s)
     def run_command
       if logger
         log_message = (log_tag.nil? ? "" : "#@log_tag ") << "sh(#@command)"

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -35,7 +35,7 @@ module Mixlib
       # * Errno::ENOENT  when the command is not available on the system (or not
       #   in the current $PATH)
       # * Chef::Exceptions::CommandTimeout  when the command does not complete
-      #   within +timeout+ seconds (default: 600s). When this happens, ShellOut
+      #   within +timeout+ seconds (default: 1200). When this happens, ShellOut
       #   will send a TERM and then KILL to the entire process group to ensure
       #   that any grandchild processes are terminated. If the invocation of
       #   the child process spawned multiple child processes (which commonly

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -37,7 +37,7 @@ describe Mixlib::ShellOut do
       its(:password) { should be_nil }
       its(:group) { should be_nil }
       its(:umask) { should be_nil }
-      its(:timeout) { should eql(600) }
+      its(:timeout) { should eql(1200) }
       its(:valid_exit_codes) { should eql([0]) }
       its(:live_stream) { should be_nil }
       its(:input) { should be_nil }


### PR DESCRIPTION
10 minutes may not be enough as a default, installing java package takes 15 minutes in a 512K DSL and i get the following error:

```
ERROR: package[openjdk-7-jdk] (java::openjdk line 44) had an error: Mixlib::ShellOut::CommandTimeout

Compiled Resource:
------------------
# Declared in /home/vagrant/chef-solo/cookbooks-2/java/recipes/openjdk.rb:44:in `block in from_file'
package("openjdk-7-jdk") do
  action :install
  retries 0
  retry_delay 2
  package_name "openjdk-7-jdk"
  version "7u25-2.3.10-1ubuntu0.12.04.2"
  cookbook_name :java
  recipe_name "openjdk"
end
```
