### PR TITLE
MIXLIB-25: Only close handles that are set to a valid handle value

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -122,8 +122,8 @@ module Mixlib
             end
 
           ensure
-            CloseHandle(process.thread_handle)
-            CloseHandle(process.process_handle)
+            CloseHandle(process.thread_handle) if process.thread_handle
+            CloseHandle(process.process_handle) if process.process_handle
           end
 
         ensure

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -288,19 +288,23 @@ module Process
 
         token = token.read_ulong
 
-        bool = CreateProcessAsUserW(
-          token,                  # User token handle
-          app,                    # App name
-          cmd,                    # Command line 
-          process_security,       # Process attributes
-          thread_security,        # Thread attributes
-          inherit,                # Inherit handles
-          hash['creation_flags'], # Creation Flags
-          env,                    # Environment
-          cwd,                    # Working directory
-          startinfo,              # Startup Info
-          procinfo                # Process Info
-        )
+        begin
+          bool = CreateProcessAsUserW(
+            token,                  # User token handle
+            app,                    # App name
+            cmd,                    # Command line
+            process_security,       # Process attributes
+            thread_security,        # Thread attributes
+            inherit,                # Inherit handles
+            hash['creation_flags'], # Creation Flags
+            env,                    # Environment
+            cwd,                    # Working directory
+            startinfo,              # Startup Info
+            procinfo                # Process Info
+          )
+        ensure
+          CloseHandle(token)
+        end
 
         unless bool
           raise SystemCallError.new("CreateProcessAsUserW (You must hold the 'Replace a process level token' permission)", FFI.errno)
@@ -348,7 +352,12 @@ module Process
     if hash['close_handles']
       CloseHandle(procinfo[:hProcess]) if procinfo[:hProcess]
       CloseHandle(procinfo[:hThread]) if procinfo[:hThread]
-      CloseHandle(token) if token
+
+      # Set fields to nil so callers don't attempt to close the handle
+      # which can result in the wrong handle being closed or an
+      # exception in some circumstances
+      procinfo[:hProcess] = nil
+      procinfo[:hThread] = nil
     end
 
     ProcessInfo.new(


### PR DESCRIPTION
A user is hitting this problem in mixlib-shellout where in certain cases we try to call the Win32 method CloseHandle with nil -- the issue is that the wrapper for CloseHandle tries to access methods of nil and thus hits an exception.

The code is definitely incorrect, and the change here ensures that we only try to close valid handles (incidentally if we had used 0 things would have worked, but under a debugger Windows would throw an exception, and also, behavior is unclear to those not familair with CloseHandle). 

This code path should not be possible though, so though the fix is correct (verified by the user), it's not clear why this flag exists in the hash. I'm trying to find more information from the user other than that the problem doesn't repro once the fix is deployed.

Another issue fixed is a handle leak -- the token handle in question is not freed in the case where you are running as a background service and try to run as an alternate user. I was able to repro the leak -- run code that creates 1000 processes using run_command and watch the handle count go over 1160 for the process -- with the fix, the handle count stays at the steady state for the process while the 1000 processes are run (about 160-180 handles).
