### PR TITLE
Update link to posix-spawn in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Apache 2 Licensed. See LICENSE for full details.
 
 ## See Also
 * `Process.spawn` in Ruby 1.9
-* [https://github.com/rtomayko/posix-spawn](posix-spawn)
+* [https://github.com/rtomayko/posix-spawn](https://github.com/rtomayko/posix-spawn)


### PR DESCRIPTION
The See Also link to posix-spawn was trying to route deeper into this repo, instead of referencing the actual URL desired.
