### PR TITLE
Fix copypasta in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Invoke crontab to edit user cron:
       crontab.run_command
 
 ## Windows Impersonation Example
-Invoke crontab to edit user cron:
+Invoke "whoami.exe" to demonstrate running a command as another user:
 
       whomai = Mixlib::ShellOut.new("whoami.exe", :user => "username", :domain => "DOMAIN", :password => "password")
       whoami.run_command      


### PR DESCRIPTION
I think someone might have accidentally copypasta'd the text under Windows Impersonation Example. :P
