### PR TITLE
Windows implementation does not kill the process on timeout

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -111,6 +111,7 @@ module Mixlib
               when WAIT_TIMEOUT
                 # Kill the process
                 if (Time.now - start_wait) > timeout
+                  TerminateProcess(process.process_handle, 1) # Terminate with a non-zero error code
                   raise Mixlib::ShellOut::CommandTimeout, "command timed out:\n#{format_for_exception}"
                 end
 


### PR DESCRIPTION
Hi,

[Despite the comment](https://github.com/opscode/mixlib-shellout/blob/master/lib/mixlib/shellout/windows.rb#L112), the windows' run_command implementation is not terminating the process.

``` ruby
  # Kill the process
  if (Time.now - start_wait) > timeout
    raise Mixlib::ShellOut::CommandTimeout, "command timed out:\n#{format_for_exception}"
  end
```

It raises an exception, ensures that some handles are closed and that pipes are empty, but it does not properly terminate the process.

It's easy to reproduce with the sleep command, because you'll have to wait the whole sleep duration:

``` ruby
require 'mixlib/shellout'
cmd = Mixlib::ShellOut.new('sleep 30')
cmd.timeout = 1
cmd.run_command
```

So I only added a call to the `TerminateProcess` function to be sure that the process is killed when the timeout is reached. Perhaps this behavior should be toggled by an additional option.
