### PR TITLE
Fix CHEF-5294 - mixlib-shellout produces nil error when execute command fails too fast

### DIFF
--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -324,11 +324,12 @@ module Mixlib
         return if attempt_reap
         @terminate_reason = "Command exceeded allowed execution time, process terminated"
         logger.error("Command exceeded allowed execution time, sending TERM") if logger
-        Process.kill(:TERM, child_pgid)
+        pid = child_pgid || @child_pid
+        Process.kill(:TERM, pid)
         sleep 3
         attempt_reap
         logger.error("Command exceeded allowed execution time, sending KILL") if logger
-        Process.kill(:KILL, child_pgid)
+        Process.kill(:KILL, pid)
         reap
 
         # Should not hit this but it's possible if something is calling waitall

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -979,7 +979,7 @@ describe Mixlib::ShellOut do
           shell_cmd.exitstatus.should == 123
         end
 
-        context "and the child is unresponsive" do
+        RSpec.shared_examples "unresponsive child" do
           let(:cmd) do
             ruby_wo_shell(<<-CODE)
               STDOUT.sync = true
@@ -1012,6 +1012,18 @@ describe Mixlib::ShellOut do
               log_output.string.should include("Command exceeded allowed execution time, sending KILL")
             end
 
+          end
+        end
+
+        context "and the child is unresponsive" do
+          include_examples "unresponsive child"
+
+          context "and the child is a zombie" do
+            before(:each) do
+              Process.stub(:getpgid) { raise Errno::EPERM }
+            end
+
+            include_examples "unresponsive child"
           end
         end
 


### PR DESCRIPTION
CHEF-5294 was closed as "pretty sure this got fixed", but I don't think it was.

The error seems to occur when:
- The child process is unresponsive
- The process group of the child process cannot be retrieved (possibly because the child process is a zombie)

I added a test for this scenario and fixed it by sending signals (TERM then KILL) to the child process group if it exists, or to the child process if there is no group.