### PR TITLE
with_logon now simulates login in unix

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -40,6 +40,7 @@ module Mixlib
     attr_accessor :user
     attr_accessor :domain
     attr_accessor :password
+    # TODO remove
     attr_accessor :with_logon
 
     # Whether to simulate logon as the user. Normally set via options passed to new
@@ -198,6 +199,7 @@ module Mixlib
 
     # The uid that the subprocess will switch to. If the user attribute was
     # given as a username, it is converted to a uid by Etc.getpwnam
+    # TODO migrate to shellout/unix.rb
     def uid
       return nil unless user
       user.kind_of?(Integer) ? user : Etc.getpwnam(user.to_s).uid
@@ -205,6 +207,7 @@ module Mixlib
 
     # The gid that the subprocess will switch to. If the group attribute is
     # given as a group name, it is converted to a gid by Etc.getgrnam
+    # TODO migrate to shellout/unix.rb
     def gid
       return group.kind_of?(Integer) ? group : Etc.getgrnam(group.to_s).gid if group
       return Etc.getpwuid(uid).gid if using_login?

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -63,6 +63,7 @@ describe Mixlib::ShellOut do
           should eql(value)
         end
 
+        # TODO add :unix_only
         context 'with an integer value for user' do
           let(:value) { 0 }
           it "should use the user-supplied uid" do
@@ -70,6 +71,7 @@ describe Mixlib::ShellOut do
           end
         end
 
+        # TODO add :unix_only
         context 'with string value for user' do
           let(:value) { username }
 
@@ -127,6 +129,7 @@ describe Mixlib::ShellOut do
           should eql(value)
         end
 
+        # TODO add :unix_only
         context 'with integer value for group' do
           let(:value) { 0 }
           it "should use the user-supplied gid" do


### PR DESCRIPTION
Added:

* Secondary groups from etc files
* Set environment variables like `su` would
* Set primary group to user's primary group if no other group specified

All only if `with_logon` is set

Fixes #77 