### PR TITLE
Init all groups a user has access to prior running comamnd

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -204,6 +204,11 @@ module Mixlib
       group.kind_of?(Integer) ? group : Etc.getgrnam(group.to_s).gid
     end
 
+    def username
+      return nil unless user
+      user.kind_of?(Integer) ? Etc.getpwuid(user).name : user
+    end
+
     def timeout
       @timeout || DEFAULT_READ_TIMEOUT
     end

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -131,6 +131,9 @@ module Mixlib
           Process.egid = gid
           Process.gid = gid
         end
+
+        # Set all groups user has access to
+        Process.initgroups(username, Process.gid)
       end
 
       def set_environment
@@ -288,7 +291,7 @@ module Mixlib
           # support the "ONESHOT" optimization (where sh -c does exec without
           # forking). To support cleaning up all the children, we need to
           # ensure they're in a unique process group.
-          # We cannot use setsid here since getpgid fails on AIX with EPERM 
+          # We cannot use setsid here since getpgid fails on AIX with EPERM
           # when parent and child have different sessions and the parent tries to get the process group,
           # hence we just create a new process group, and have the same session.
           Process.setpgrp


### PR DESCRIPTION
This changes would fix chef/chef#2342.

The current problem is that if a user has access to other groups, and the command is accessing for example a file with owner different than mixlib specified user/group pair and user is member of file group owner, the command fails with a permission denied exception while it should succeed.

By using `Process.initgroups`, it effectively sets all groups a user has access to prior running the command.

I'm not sure how tests could be written for that. Testing would meaning doing the actual work performed by `initgroups` and then checking that what I done is right. I'm open to suggestions if you have ideas.

Tested manually for now running a recipe file using `chef-apply` and then a mixlib-shellout script.

Regards,
Matt