### PR TITLE
Change mixlib spec test to pass on windows by invoking powershell explicitly.

### DIFF
--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -951,7 +951,7 @@ describe Mixlib::ShellOut do
 
         context 'on windows', :windows_only do
           let(:cmd) do
-            "sleep 10"
+            'powershell -c "sleep 10"'
           end
 
           it "should raise CommandTimeout" do


### PR DESCRIPTION
This test was not passing on my local box without explicitly calling powershell -c.