### PR TITLE
Refactor platform dependent gem creation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,8 @@ source 'https://rubygems.org'
 gemspec :name => "mixlib-shellout"
 
 group(:test) do
-
   gem "rspec_junit_formatter"
   gem 'rake'
-
 end
 
 group(:development) do

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,11 @@
 require 'rspec/core/rake_task'
 require 'rubygems/package_task'
+require 'mixlib/shellout/version'
 
 Dir[File.expand_path("../*gemspec", __FILE__)].reverse.each do |gemspec_path|
   gemspec = eval(IO.read(gemspec_path))
   Gem::PackageTask.new(gemspec).define
 end
-
-require 'mixlib/shellout/version'
 
 desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec) do |t|
@@ -14,7 +13,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 desc "Build it and ship it"
-task :ship => [:clean, :gem] do
+task ship: [:clobber_package, :gem] do
   sh("git tag #{Mixlib::ShellOut::VERSION}")
   sh("git push opscode --tags")
   Dir[File.expand_path("../pkg/*.gem", __FILE__)].reverse.each do |built_gem|
@@ -22,4 +21,4 @@ task :ship => [:clean, :gem] do
   end
 end
 
-task :default => :spec
+task default: :spec

--- a/mixlib-shellout-windows.gemspec
+++ b/mixlib-shellout-windows.gemspec
@@ -1,0 +1,8 @@
+gemspec = eval(File.read(File.expand_path("../mixlib-shellout.gemspec", __FILE__)))
+
+gemspec.platform = Gem::Platform.new(["universal", "mingw32"])
+
+gemspec.add_dependency "win32-process", "~> 0.7.5"
+gemspec.add_dependency "windows-pr", "~> 1.2.4"
+
+gemspec

--- a/mixlib-shellout-x86-mingw32.gemspec
+++ b/mixlib-shellout-x86-mingw32.gemspec
@@ -1,9 +1,0 @@
-# x86-mingw32 Gemspec #
-gemspec = eval(IO.read(File.expand_path("../mixlib-shellout.gemspec", __FILE__)))
-
-gemspec.platform = "x86-mingw32"
-
-gemspec.add_dependency "win32-process", "~> 0.7.1"
-gemspec.add_dependency "windows-pr", "~> 1.2.2"
-
-gemspec


### PR DESCRIPTION
Since we don't actually have platform specific code, only dependencies, we can use this structure to generate gems based on just the ABI needed.  Hence we have a mingw32 package (supports both 32 and 64-bit outputs) and an mswin32 package (good luck fellas..).  We also have a pure ruby output for test purposes.