### PR TITLE
Fix 2 ruby warnings for uninitialized variables

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -171,6 +171,7 @@ module Mixlib
       @cwd = nil
       @valid_exit_codes = [0]
       @terminate_reason = nil
+      @timeout = nil
 
       if command_args.last.is_a?(Hash)
         parse_options(command_args.pop)

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -106,6 +106,7 @@ module Mixlib
         propagate_pre_exec_failure
         get_child_pgid
 
+        @status = nil
         @result = nil
         @execution_time = 0
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,7 @@ RSpec.configure do |config|
 
   config.run_all_when_everything_filtered = true
   config.treat_symbols_as_metadata_keys_with_true_values = true
+
+  config.warnings = true
+
 end


### PR DESCRIPTION
I enabled ruby warnings on the chef-config subproject, and got a ton of warning spam from shellout. Adding warnings to the tests here revealed these two issues.

@chef/client-core 