### PR TITLE
prevent shellout from attempting to execute a directory on windows

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -301,13 +301,17 @@ module Mixlib
         # The OS will search through valid the extensions and look
         # for a binary there.
         def self.find_executable(path)
-          return path if File.executable? path
+          return path if executable? path
 
           pathext.each do |ext|
             exe = "#{path}#{ext}"
-            return exe if File.executable? exe
+            return exe if executable? exe
           end
           return nil
+        end
+
+        def self.executable?(path)
+          File.executable?(path) && !File.directory?(path)
         end
       end
     end # class

--- a/spec/mixlib/shellout/windows_spec.rb
+++ b/spec/mixlib/shellout/windows_spec.rb
@@ -159,6 +159,35 @@ describe 'Mixlib::ShellOut::Windows', :windows_only do
         end
       end
 
+      context 'with extensionless executable' do
+        let(:stubbed_shell_out) { shell_out }
+        let(:executable_path) { 'C:\Windows\system32/ping.EXE' }
+        let(:cmd) { 'ping' }
+
+        before do
+          allow(ENV).to receive(:[]).with('PATH').and_return('C:\Windows\system32')
+          allow(ENV).to receive(:[]).with('PATHEXT').and_return('.EXE')
+          allow(ENV).to receive(:[]).with('COMSPEC').and_return('C:\Windows\system32\cmd.exe')
+          allow(File).to receive(:executable?).and_return(false)
+          allow(File).to receive(:executable?).with(executable_path).and_return(true)
+        end
+
+        it 'should return with full path with extension' do
+          is_expected.to eql([executable_path, cmd])
+        end
+
+        context 'there is a directory named after command' do
+          before do
+            # File.executable? returns true for directories
+            allow(File).to receive(:executable?).with(cmd).and_return(true)
+          end
+
+          it 'should return with full path with extension' do
+            is_expected.to eql([executable_path, cmd])
+          end
+        end
+      end
+
       context 'with batch files' do
         let(:stubbed_shell_out) { shell_out.tap(&with_valid_exe_at_location) }
         let(:cmd_invocation) { "cmd /c \"#{cmd}\"" }

--- a/spec/mixlib/shellout/windows_spec.rb
+++ b/spec/mixlib/shellout/windows_spec.rb
@@ -170,6 +170,7 @@ describe 'Mixlib::ShellOut::Windows', :windows_only do
           allow(ENV).to receive(:[]).with('COMSPEC').and_return('C:\Windows\system32\cmd.exe')
           allow(File).to receive(:executable?).and_return(false)
           allow(File).to receive(:executable?).with(executable_path).and_return(true)
+          allow(File).to receive(:directory?).and_return(false)            
         end
 
         it 'should return with full path with extension' do
@@ -180,6 +181,7 @@ describe 'Mixlib::ShellOut::Windows', :windows_only do
           before do
             # File.executable? returns true for directories
             allow(File).to receive(:executable?).with(cmd).and_return(true)
+            allow(File).to receive(:directory?).with(cmd).and_return(true)            
           end
 
           it 'should return with full path with extension' do


### PR DESCRIPTION
ruby considers directories to be executable. This seems to be true for both linux and windows, however the shellout logic on windows uses `executable?` to determine if a path is executable. When trying to find the correct path to run, shellout starts with just the command given (ie `knife`) to see if there is an executable by the same name in the current directory. So if the user so happens to have a directory with that same name, an exception is raised:

```
Input/output error - CreateProcessW (Errno::EIO)
```

Because we are attempting to create a process with the directory.

This fixes https://github.com/chef/chef-dk/issues/482
