### PR TITLE
make tests pass when run by a domain joined user

### DIFF
--- a/mixlib-shellout.gemspec
+++ b/mixlib-shellout.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
+  s.add_dependency "wmi-lite", "~> 1.0"
   s.add_development_dependency "rspec", "~> 3.0"
 
   s.bindir       = "bin"

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1116,8 +1116,21 @@ describe Mixlib::ShellOut do
             'powershell -c "sleep 10"'
           end
 
+          before do
+            require "wmi-lite/wmi"
+            allow(WmiLite::Wmi).to receive(:new)
+            allow(Mixlib::ShellOut::Windows::Utils).to receive(:kill_process_tree)
+          end
+
           it "should raise CommandTimeout" do
             Timeout::timeout(5) do
+              expect { executed_cmd }.to raise_error(Mixlib::ShellOut::CommandTimeout)
+            end
+          end
+
+          context 'and child processes should be killed' do
+            it 'kills the child processes' do
+              expect(Mixlib::ShellOut::Windows::Utils).to receive(:kill_process_tree)
               expect { executed_cmd }.to raise_error(Mixlib::ShellOut::CommandTimeout)
             end
           end

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -621,7 +621,7 @@ describe Mixlib::ShellOut do
     end
 
     context "when running under Windows", :windows_only do
-      let(:cmd) { 'whoami.exe' }
+      let(:cmd) { '%windir%/system32/whoami.exe' }
       let(:running_user) { shell_cmd.run_command.stdout.strip.downcase }
 
       context "when no user is set" do
@@ -629,7 +629,7 @@ describe Mixlib::ShellOut do
         # to match how whoami returns the information
 
         it "should run as current user" do
-          expect(running_user).to eql("#{ENV['COMPUTERNAME'].downcase}\\#{ENV['USERNAME'].downcase}")
+          expect(running_user).to eql("#{ENV['USERDOMAIN'].downcase}\\#{ENV['USERNAME'].downcase}")
         end
       end
 


### PR DESCRIPTION
When strarting to test some work in this gem, I am getting 2 failed tests which this should fix.

1. Force the test to use the correct whoami.exe which all ci should have but is different from the one shipped with chefdk and does not return the computer name or domain name. It just returns the user name.

2. User USERDOMAIN instead of COMPUTERNAME which should resolve corectly if user is domain joined or not.