### PR TITLE
convert environment hash keys to strings

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -332,7 +332,11 @@ module Mixlib
         when 'log_tag'
           self.log_tag = setting
         when 'environment', 'env'
-          self.environment = setting || {}
+          if setting
+            self.environment = Hash[setting.map{|(k,v)| [k.to_s,v]}]
+          else
+            self.environment = {}
+          end
         when 'login'
           self.login = setting
         else

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -477,6 +477,14 @@ describe Mixlib::ShellOut do
           end
         end
 
+        context 'when setting environments with symbols' do
+          let(:options) { { :environment => { SYMBOL: 'cymbal' } } }
+
+          it "should also set the enviroment" do
+            expect(shell_cmd.environment).to eql({'SYMBOL' => 'cymbal'})
+          end
+        end
+
         context 'when :environment is set to nil' do
           let(:options) { { :environment => nil } }
 


### PR DESCRIPTION
By converting the hash keys to strings, we can use symbols in our environment blocks with the pretty, new Ruby 1.9 hash style:

```
    environment {FOO: 'bar', SHELL: 'zsh'}
```

I was initially going to place this at https://github.com/chef/mixlib-shellout/blob/master/lib/mixlib/shellout/unix.rb#L174 but it looks like there's no way to write tests for that, and would require repeating it for Windows too.

@jordane