### PR TITLE
fixes regression where CreateProcessWithLogonW wants a boolean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+before_install:
+  - gem update bundler
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,7 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200"
-    - ruby_version: "193"
+    - ruby_version: "21"
 
 clone_folder: c:\projects\mixlib-shellout
 clone_depth: 1

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -42,7 +42,7 @@ module Process::Functions
     [:buffer_in, :buffer_in, :buffer_in, :ulong, :ulong, :pointer], :bool
 
   attach_pfunc :CreateProcessAsUserW,
-    [:ulong, :buffer_in, :buffer_in, :pointer, :pointer, :bool,
+    [:ulong, :buffer_in, :buffer_inout, :pointer, :pointer, :int,
       :ulong, :buffer_in, :buffer_in, :pointer, :pointer], :bool
 
   ffi_lib :user32


### PR DESCRIPTION
this fixes https://github.com/chef/chef/issues/4464 introduced with https://github.com/chef/mixlib-shellout/commit/c302f8c61d8d50da4d4797d583fecc18a0a8bd1c 

That changed several bool parameters to int and accommodated a downstream change to `CreateProcessW` which changed the `inherits` arg from `:bool` to `int` (see https://github.com/djberg96/win32-process/pull/20). However the `CreateProcessAsUserW` function defined here is a `:bool` and breaks when passed an int.

I think ultimately it would be better for the downstream `CreateProcessW` to revert to a `bool` and keep these two consistent.

Both functions `inherit` args are documented as `:bool` in the following links:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms682429(v=vs.85).aspx
https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
