### PR TITLE
Handle env vars which are convertible to string

### DIFF
--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -68,7 +68,8 @@ module Mixlib
 
       # Merges the two environments for the process
       def process_environment
-        logon_environment.merge(self.environment)
+        env = logon_environment.merge(self.environment)
+        env.each{ |k,v| env[k] = v.to_s }
       end
 
       # Run the command, writing the command's standard out and standard error

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -379,26 +379,29 @@ describe Mixlib::ShellOut do
           end
         end
         # Setting the user should set the env variables
-	describe '#process_environment' do
-	  subject { super().process_environment }
-	  it { is_expected.to eq ({'HOME'=>dir, 'SHELL'=>shell, 'USER'=>'catbert', 'LOGNAME'=>'catbert', 'PATH'=>path, 'IFS'=>"\t\n"}) }
-	end
+        describe '#process_environment' do
+          subject { super().process_environment }
+          it { is_expected.to eq ({'HOME'=>dir, 'SHELL'=>shell, 'USER'=>'catbert', 'LOGNAME'=>'catbert', 'PATH'=>path, 'IFS'=>"\t\n"}) }
+        end
         # Setting the user with overriding env variables should override
-	context 'when adding environment variables' do
-	  before(:each){shell_cmd.environment={'PATH'=>'/lord:/of/the/dance', 'CUSTOM'=>'costume'}}
-	  it 'should preserve custom variables' do
-	    expect(shell_cmd.process_environment['PATH']).to eq('/lord:/of/the/dance')
-	  end
+        context 'when adding environment variables' do
+          before(:each){shell_cmd.environment={'PATH'=>'/lord:/of/the/dance', 'CUSTOM'=>'costume', 'PORT'=>22}}
+          it 'should preserve custom variables' do
+            expect(shell_cmd.process_environment['PATH']).to eq('/lord:/of/the/dance')
+          end
           # Setting the user with additional env variables should have both
-	  it 'should allow new variables' do
-	    expect(shell_cmd.process_environment['CUSTOM']).to eq('costume')
-	  end
-	end
+          it 'should allow new variables' do
+            expect(shell_cmd.process_environment['CUSTOM']).to eq('costume')
+          end
+          it 'should convert variables to strings' do
+            expect(shell_cmd.process_environment['PORT']).to eq('22')
+          end
+        end
         # Setting the user should set secondary groups
-	describe '#sgids' do
-	  subject { super().sgids }
-	  it { is_expected.to match_array([52,700]) }
-	end
+        describe '#sgids' do
+          subject { super().sgids }
+          it { is_expected.to match_array([52,700]) }
+        end
       end
       # Setting login with user should throw errors
       context 'when not setting a user id' do


### PR DESCRIPTION
To change an environment variable, you must be set its value as a string
otherwise you get an exception:

    TypeError: no implicit conversion of Fixnum into String

This change attempts to convert env var values in the process environment
to strings.