### PR TITLE
Require Ruby 2.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 
 before_install:
   - gem update bundler

--- a/mixlib-shellout.gemspec
+++ b/mixlib-shellout.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = "info@chef.io"
   s.homepage = "https://www.chef.io/"
 
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.1"
 
   s.add_development_dependency "rspec", "~> 3.0"
 

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -17,10 +17,7 @@ describe Mixlib::ShellOut do
   let(:ruby_code) { raise 'define let(:ruby_code)' }
   let(:options) { nil }
 
-  # On some testing environments, we have gems that creates a deprecation notice sent
-  # out on STDERR. To fix that, we disable gems on Ruby 1.9.2
-  let(:ruby_eval) { lambda { |code| "ruby #{disable_gems} -e '#{code}'" } }
-  let(:disable_gems) { ( ruby_19? ? '--disable-gems' : '') }
+  let(:ruby_eval) { lambda { |code| "ruby -e '#{code}'" } }
 
   context 'when instantiating' do
     subject { shell_cmd }
@@ -1144,7 +1141,6 @@ describe Mixlib::ShellOut do
         context 'on unix', :unix_only do
           def ruby_wo_shell(code)
             parts = %w[ruby]
-            parts << "--disable-gems" if ruby_19?
             parts << "-e"
             parts << code
           end

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -1,12 +1,3 @@
-
-def ruby_19?
-  !!(RUBY_VERSION =~ /^1.9/)
-end
-
-def ruby_18?
-  !!(RUBY_VERSION =~ /^1.8/)
-end
-
 def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end


### PR DESCRIPTION
Just removes some 1.9 logic from testing.

Signed-off-by: Tim Smith <tsmith@chef.io>