### PR TITLE
WIP: Add syntax sugar to avoid ceremony

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -109,6 +109,10 @@ module Mixlib
 
     attr_reader :stdin_pipe, :stdout_pipe, :stderr_pipe, :process_status_pipe
 
+    def self.run_command(*args, &block)
+      new(*args, &block).tap(&:run_command)
+    end
+
     # === Arguments:
     # Takes a single command, or a list of command fragments. These are used
     # as arguments to Kernel.exec. See the Kernel.exec documentation for more

--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -113,6 +113,12 @@ module Mixlib
       new(*args, &block).tap(&:run_command)
     end
 
+    def self.error!(*args, &block)      run_command(*args, &block).error!     end
+    def self.error?(*args, &block)      run_command(*args, &block).error?     end
+    def self.stdout(*args, &block)      run_command(*args, &block).stdout     end
+    def self.stderr(*args, &block)      run_command(*args, &block).stderr     end
+    def self.exitstatus(*args, &block)  run_command(*args, &block).exitstatus end
+
     # === Arguments:
     # Takes a single command, or a list of command fragments. These are used
     # as arguments to Kernel.exec. See the Kernel.exec documentation for more

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1526,4 +1526,18 @@ describe Mixlib::ShellOut do
       end
     end
   end
+
+  describe ".run_command" do
+    let(:command) { "yes | head -n1" }
+
+    it "returns a ShellOut instance" do
+      result = Mixlib::ShellOut.run_command(command)
+      expect(result).to be_a(Mixlib::ShellOut)
+    end
+
+    it "runs the requested command" do
+      result = Mixlib::ShellOut.run_command(command)
+      expect(result.stdout).to eq("y\n")
+    end
+  end
 end

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1528,7 +1528,7 @@ describe Mixlib::ShellOut do
   end
 
   describe ".run_command" do
-    let(:command) { "yes | head -n1" }
+    let(:command) { "echo 'hello'" }
 
     it "returns a ShellOut instance" do
       result = Mixlib::ShellOut.run_command(command)
@@ -1537,7 +1537,49 @@ describe Mixlib::ShellOut do
 
     it "runs the requested command" do
       result = Mixlib::ShellOut.run_command(command)
-      expect(result.stdout).to eq("y\n")
+      expect(result.stdout).to eq("hello\n")
+    end
+  end
+
+  describe ".error!" do
+    it "raises an exception when the command fails" do
+      expect {
+        Mixlib::ShellOut.error!("ls not_a_directory")
+      }.to raise_error(Mixlib::ShellOut::ShellCommandFailed)
+    end
+
+    it "does not raise an error when the command succeeds" do
+      expect {
+        Mixlib::ShellOut.error!("echo 'hello'")
+      }.not_to raise_error
+    end
+  end
+
+  describe ".error?" do
+    it "returns true when the command fails" do
+      expect(Mixlib::ShellOut.error?("ls not_a_directory")).to eq(true)
+    end
+
+    it "returns false when the command succeeds" do
+      expect(Mixlib::ShellOut.error?("echo 'hello'")).to eq(false)
+    end
+  end
+
+  describe ".stdout" do
+    it "returns the process's stdout" do
+      expect(Mixlib::ShellOut.stdout("echo 'hello'")).to eq("hello\n")
+    end
+  end
+
+  describe ".stderr" do
+    it "returns the process's stderr" do
+      expect(Mixlib::ShellOut.stderr("echo 'hello' 1>&2")).to eq("hello\n")
+    end
+  end
+
+  describe ".exitstatus" do
+    it "returns the process's exitstatus" do
+      expect(Mixlib::ShellOut.exitstatus("echo 'hello'")).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Hi,

I've run into this library a few times recently, and while I really like how well this abstracts running commands on the underlying OS, it feels clumsy to use because it requires more ceremony than I'd expect. A scenario I recently ran into was where we wanted to run some code, but expected it to always succeed and didn't care about the output. Our code ended up like this:

```
Mixlib::Shellout.new("run some_command").run_command
```

When we wrote tests for this we were faced with either of these two options:

```
expect_any_instance_of(Mixlib::Shellout).to receive(:run_command)
```

or 

```
command = double(:mixlib_shellout)
expect(command).to receive(:run_command)
allow(Mixlib::Shellout).to receive(:new).with("run some_command").and_return(command)
```

When ideally we'd have been able to do:

```
expect(Mixlib::Shellout).to receive(:run_command).with("run some_command")
```

Another scenario I've run into recently ended up with code like this:

```
command = Mixlib::Shellout.new("run some_command")
command.run_command
if command.exitstatus == 0
  # ...
```

It would have been much nicer to be able to just do:

```
if Mixlib::Shellout.exitstatus("run some_command")
  # ...
```

This PR was not really meant to be merged as-is, but I wanted to try out the idea and see how it would work. WDYT?