### PR TITLE
Added `elevated` option to launch process with elevated privileges

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -109,6 +109,9 @@ module Mixlib
 
     attr_reader :stdin_pipe, :stdout_pipe, :stderr_pipe, :process_status_pipe
 
+    # Runs windows process with elevated privileges. Required for Powershell commands which need elevated privileges
+    attr_accessor :elevated
+
     # === Arguments:
     # Takes a single command, or a list of command fragments. These are used
     # as arguments to Kernel.exec. See the Kernel.exec documentation for more
@@ -172,6 +175,7 @@ module Mixlib
       @valid_exit_codes = [0]
       @terminate_reason = nil
       @timeout = nil
+      @elevated = false
 
       if command_args.last.is_a?(Hash)
         parse_options(command_args.pop)
@@ -339,6 +343,8 @@ module Mixlib
           end
         when "login"
           self.login = setting
+        when "elevated"
+          self.elevated = setting
         else
           raise InvalidCommandOption, "option '#{option.inspect}' is not a valid option for #{self.class.name}"
         end

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -27,7 +27,9 @@ module Mixlib
 
       # Option validation that is unix specific
       def validate_options(opts)
-        # No options to validate, raise exceptions here if needed
+        if opts[:elevated]
+          raise InvalidCommandOption, "Option `elevated` is supported for Powershell commands only"
+        end
       end
 
       # Whether we're simulating a login shell

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -35,6 +35,10 @@ module Mixlib
         if opts[:user] && !opts[:password]
           raise InvalidCommandOption, "You must supply a password when supplying a user in windows"
         end
+
+        if opts[:elevated] && opts[:elevated] != true && opts[:elevated] != false
+          raise InvalidCommandOption, "Invalid value passed for `elevated`. Please provide true/false."
+        end
       end
 
       #--
@@ -71,6 +75,7 @@ module Mixlib
           create_process_args[:domain] = domain.nil? ? "." : domain
           create_process_args[:with_logon] = with_logon if with_logon
           create_process_args[:password] = password if password
+          create_process_args[:elevated] = elevated if elevated
 
           #
           # Start the process

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -660,7 +660,7 @@ describe Mixlib::ShellOut do
           let(:options) { { :user => user, :password => password, :elevated => true } }
 
           it "raises error" do
-            expect { running_user }.to raise_error("Logon failure: the user has not been granted the requested logon type at this computer. - LogonUserW")
+            expect { running_user }.to raise_error("Logon failure: the user has not been granted the requested logon type at this computer. - LogonUserW (You must hold `Log on as a service` and `Log on as a batch job` permissions.)")
           end
         end
       end

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -655,6 +655,14 @@ describe Mixlib::ShellOut do
         it "should run as specified user" do
           expect(running_user).to eql("#{ENV['COMPUTERNAME'].downcase}\\#{user}")
         end
+
+        context "when :elevated => true" do
+          let(:options) { { :user => user, :password => password, :elevated => true } }
+
+          it "raises error" do
+            expect { running_user }.to raise_error("Logon failure: the user has not been granted the requested logon type at this computer. - LogonUserW")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The token automatically generated by `CreateProcessWithLogonW`  is a "filtered" logon token and not the one with full admin privileges. Hence using `CreateProcessAsUserW` when `elevated => true` is passed.
If a user wants to run some command which requires elevated privileges, then `elevated` option should be passed.

fixes https://github.com/chef/mixlib-shellout/issues/142