### PR TITLE
Make Mixlib::ShellOut::EmptyWindowsCommand inherit from ShellCommandFailed

### DIFF
--- a/lib/mixlib/shellout/exceptions.rb
+++ b/lib/mixlib/shellout/exceptions.rb
@@ -4,6 +4,6 @@ module Mixlib
     class ShellCommandFailed < Error; end
     class CommandTimeout < Error; end
     class InvalidCommandOption < Error; end
-    class EmptyWindowsCommand < Error; end
+    class EmptyWindowsCommand < ShellCommandFailed; end
   end
 end


### PR DESCRIPTION
Chef rescues Mixlib::ShellOut::ShellCommandFailed, SystemCallError in a few places.
Recent refactors caused EmptyWindowsCommand to be correctly raised where we still
unintentionally raised SystemCallError due to a bad FFI call. This gets us closer
to not needing to cover these edge cases in rescue clauses everywhere.

Signed-off-by: Bryan McLellan <btm@chef.io>