### PR TITLE
Avoid EmptyWindowsCommand error on Windows when the command starts with spaces

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -229,12 +229,11 @@ module Mixlib
 
       # FIXME: this extracts ARGV[0] but is it correct?
       def candidate_executable_for_command(command)
-        if command =~ /^\s*"(.*?)"/
-          # If we have quotes, do an exact match
+        if command =~ /^\s*"(.*?)"/ || command =~ /^\s*([^\s]+)/
+          # If we have quotes, do an exact match, else pick the first word ignoring the leading spaces
           $1
         else
-          # Otherwise check everything up to the first space
-          command[0, command.index(/\s/) || command.length].strip
+          ""
         end
       end
 


### PR DESCRIPTION
On Windows if the command is not quoted but has spaces in leading, the function `candidate_executable_for_command` returns nothing, by example:
```
java_oracle_install[jre] had an error: Mixlib::ShellOut::EmptyWindowsCommand: could not parse script/executable out of command: ` tar xvzf "c:/chef/cache/jre-8u131-windows-x64.tar.gz" -C "c:/chef/cache" --no-same-owner`
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/mixlib-shellout-2.3.2-universal-mingw32/lib/mixlib/shellout/windows.rb:197:in `command_to_run'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/mixlib-shellout-2.3.2-universal-mingw32/lib/mixlib/shellout/windows.rb:61:in `run_command'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/mixlib-shellout-2.3.2-universal-mingw32/lib/mixlib/shellout.rb:263:in `run_command'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.8.5-universal-mingw32/lib/chef/mixin/shell_out.rb:171:in `shell_out_command'
C:/opscode/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.8.5-universal-mingw32/lib/chef/mixin/shell_out.rb:114:in `shell_out'
```