### PR TITLE
Fix a bare rescue on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,5 @@ Lint/UselessAccessModifier:
   Exclude:
     - 'lib/mixlib/shellout/windows/core_ext.rb'
 
-# Set for mixlib-shell-out-windows.gemspec
-Security/Eval:
-  Enabled: false
-
 Style/HashSyntax:
   Enabled: true

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -122,7 +122,7 @@ module Mixlib
                     wmi = WmiLite::Wmi.new
                     kill_process_tree(process.process_id, wmi, logger)
                     Process.kill(:KILL, process.process_id)
-                  rescue
+                  rescue SystemCallError
                     logger.warn("Failed to kill timed out process #{process.process_id}") if logger
                   end
 
@@ -357,7 +357,7 @@ module Mixlib
           ].join)
         end
         Process.kill(:KILL, instance.wmi_ole_object.processid)
-      rescue
+      rescue SystemCallError
         if logger
           logger.debug([
             "Failed to kill child process #{child_pid}::",

--- a/mixlib-shellout-windows.gemspec
+++ b/mixlib-shellout-windows.gemspec
@@ -1,4 +1,4 @@
-gemspec = eval(File.read(File.expand_path("../mixlib-shellout.gemspec", __FILE__)))
+gemspec = instance_eval(File.read(File.expand_path("../mixlib-shellout.gemspec", __FILE__)))
 
 gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 


### PR DESCRIPTION
To fix rubocop errors we removed the rescues in earlier PR https://github.com/chef/mixlib-shellout/pull/157/files#diff-a49639dc02ce0578d8000ee0aecf5210.
So we have added them back here again to make those as specific as possible.

Added `SystemCallError` to make the rescues as specific as possible because it is parent of `Errno::EIO` and will cover all required error now.

