### PR TITLE
Load and unload user profile as required

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -88,7 +88,7 @@ module Mixlib
           #
           # Start the process
           #
-          process = Process.create(create_process_args)
+          process, profile, token = Process.create(create_process_args)
           logger.debug(format_process(process, app_name, command_line, timeout)) if logger
           begin
             # Start pushing data into input
@@ -143,6 +143,8 @@ module Mixlib
           ensure
             CloseHandle(process.thread_handle) if process.thread_handle
             CloseHandle(process.process_handle) if process.process_handle
+            Process.unload_user_profile(token, profile) if profile
+            CloseHandle(token) if token
           end
 
         ensure

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -109,7 +109,6 @@ module Process
   class << self
 
     def create(args)
-
       unless args.kind_of?(Hash)
         raise TypeError, "hash keyword arguments expected"
       end
@@ -127,9 +126,9 @@ module Process
 
       # Set default values
       hash = {
-        "app_name"       => nil,
+        "app_name" => nil,
         "creation_flags" => 0,
-        "close_handles"  => true,
+        "close_handles" => true,
       }
 
       # Validate the keys, and convert symbols and case to lowercase strings.
@@ -309,10 +308,10 @@ module Process
           end
 
           if logon_has_roaming_profile?
-            msg = %W{
+            msg = %w{
               Mixlib does not currently support executing commands as users
               configured with Roaming Profiles. [%s]
-            }.join(' ') % logon.encode('UTF-8').unpack("A*")
+            }.join(" ") % logon.encode("UTF-8").unpack("A*")
             raise UnsupportedFeature.new(msg)
           end
 
@@ -325,7 +324,7 @@ module Process
         else
 
           create_process_with_logon(logon, domain, passwd, LOGON_WITH_PROFILE,
-            app,cmd, hash["creation_flags"], env, cwd, startinfo, procinfo)
+            app, cmd, hash["creation_flags"], env, cwd, startinfo, procinfo)
 
         end
 
@@ -379,7 +378,7 @@ module Process
     end
 
     def unload_user_profile(token, profile)
-      if profile[:hProfile].zero?
+      if profile[:hProfile] == 0
         warn "\n\nWARNING: Profile not loaded\n"
       else
         unless UnloadUserProfile(token, profile[:hProfile])
@@ -408,20 +407,20 @@ module Process
 
       unless bool
         msg = case FFI.errno
-        when ERROR_PRIVILEGE_NOT_HELD
-          %w{
-            CreateProcessAsUserW (User '%s' must hold the 'Replace a process
-            level token' and 'Adjust Memory Quotas for a process' permissions.
-            Logoff the user after adding this right to make it effective.)
-          }.join(' ') % ::ENV['USERNAME']
-        else
-          'CreateProcessAsUserW failed.'
-        end
+              when ERROR_PRIVILEGE_NOT_HELD
+                [
+                  %{CreateProcessAsUserW (User '%s' must hold the 'Replace a process},
+                  %{level token' and 'Adjust Memory Quotas for a process' permissions.},
+                  %{Logoff the user after adding this right to make it effective.)},
+                ].join(" ") % ::ENV["USERNAME"]
+              else
+                "CreateProcessAsUserW failed."
+              end
         raise SystemCallError.new(msg, FFI.errno)
       end
     end
 
-    def create_process_with_logon(logon, domain, passwd, logon_flags, app,cmd,
+    def create_process_with_logon(logon, domain, passwd, logon_flags, app, cmd,
       creation_flags, env, cwd, startinfo, procinfo)
 
       bool = CreateProcessWithLogonW(


### PR DESCRIPTION
- bind related C++ funcs, add types and constants
- refactor similar func calls into component methods
- make Process#create return trio of process-related objects
- ensure delayed profile unload and token destruction

Signed-off-by: Brian Warsing <brian.warsing@visioncritical.com>

When `elevated: true` or running in a "service window station", loads and unloads the given `logon` user's profile, as required.

Related Issue: #168

Notes:

Due to the complexities involved, I have elected not to include support for
roaming profiles. As such, if `Process#create` calls `CreateProcessAsUserW` and the `logon` has roaming profile, `Mixlib` will raise an `UnsupportedFeature`
exception. Also, I have not included a **feature toggle** for profile loading, but would be happy to do so...
