### PR TITLE
Support array args on windows WIP

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "rspec/core/rake_task"
 
 Bundler::GemHelper.install_tasks name: "mixlib-shellout"
 
-task default: [:style, :spec]
+task default: [:spec, :style]
 
 desc "Run specs"
 RSpec::Core::RakeTask.new(:spec) do |spec|


### PR DESCRIPTION
Implements correct quoting and escaping of arguments on windows.

That means that this works right now:

```ruby
filename = 'c:\program files'
shell_out('dir', filename);
```

So all the defensive coding around quotes-around-filepaths -- which were
all actually buggy even when they worked (trailing backslashes would
fail) -- are unnecessary and arguments can just be passed in as an array
and this code will sort it out.

We rely on the existing determination of if metacharacters mean it needs
to run under cmd and if it needs the ^ quoting which seems to be well
tested, and which all runs after this does.