### PR TITLE
Fix return type of Process.create to be a ProcessInfo instance again.

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -88,7 +88,7 @@ module Mixlib
           #
           # Start the process
           #
-          process, profile, token = Process.create(create_process_args)
+          process, profile, token = Process.create3(create_process_args)
           logger.debug(format_process(process, app_name, command_line, timeout)) if logger
           begin
             # Start pushing data into input

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -109,6 +109,10 @@ module Process
   class << self
 
     def create(args)
+      create3(args).first
+    end
+
+    def create3(args)
       unless args.is_a?(Hash)
         raise TypeError, "hash keyword arguments expected"
       end


### PR DESCRIPTION
This fixes compatibility with win32-process' Process.create while
maintaining the rest of our changes.

The break came from PR #177, which is fairly extensive, so I'm only
rolling out the return type change on this method.

Signed-off-by: Ryan Davis <zenspider@chef.io>