### PR TITLE
Windows: fetch env variables for specified users

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -66,7 +66,6 @@ module Mixlib
           #
           # Set cwd, environment, appname, etc.
           #
-          environment = inherit_environment.map { |k, v| "#{k}=#{v}" } unless with_logon
           app_name, command_line = command_to_run(combine_args(*command))
           create_process_args = {
             app_name: app_name,
@@ -76,7 +75,7 @@ module Mixlib
               stderr: stderr_write,
               stdin: stdin_read,
             },
-            environment: environment,
+            environment: inherit_environment.map { |k, v| "#{k}=#{v}" },
             close_handles: false,
           }
           create_process_args[:cwd] = cwd if cwd

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -66,6 +66,7 @@ module Mixlib
           #
           # Set cwd, environment, appname, etc.
           #
+          environment = inherit_environment.map { |k, v| "#{k}=#{v}" } unless with_logon
           app_name, command_line = command_to_run(combine_args(*command))
           create_process_args = {
             app_name: app_name,
@@ -75,7 +76,7 @@ module Mixlib
               stderr: stderr_write,
               stdin: stdin_read,
             },
-            environment: inherit_environment.map { |k, v| "#{k}=#{v}" },
+            environment: environment,
             close_handles: false,
           }
           create_process_args[:cwd] = cwd if cwd

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -18,6 +18,7 @@
 #
 
 require "win32/process"
+require "ffi/win32/extensions"
 
 # Add new constants for Logon
 module Process::Constants

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -186,6 +186,14 @@ module Process
         logon, passwd, domain = format_creds_from_hash(hash)
         logon_type = hash["elevated"] ? LOGON32_LOGON_BATCH : LOGON32_LOGON_INTERACTIVE
         token = logon_user(logon, domain, passwd, logon_type)
+        logon_ptr = FFI::MemoryPointer.from_string(logon)
+        profile = PROFILEINFO.new.tap do |dat|
+          dat[:dwSize]     = dat.size
+          dat[:dwFlags]    = 1
+          dat[:lpUserName] = logon_ptr
+        end
+
+        load_user_profile(token, profile.pointer)
         env_list = retrieve_environment_variables(token)
       end
 

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -47,7 +47,7 @@ module Process::Constants
   WIN32_PROFILETYPE_PT_ROAMING_PREEXISTING = 0x08
 
   # The environment block list ends with two nulls (\0\0).
-  ENVIROMENT_BLOCK_ENDS = "\0\0".freeze
+  ENVIRONMENT_BLOCK_ENDS = "\0\0".freeze
 end
 
 # Structs required for data handling

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -577,7 +577,7 @@ module Process
       offset = 0
       loop do
         new_str_pointer = str_ptr.+(offset)
-        break if new_str_pointer.read_string(2) == ENVIROMENT_BLOCK_ENDS
+        break if new_str_pointer.read_string(2) == ENVIRONMENT_BLOCK_ENDS
 
         environment = new_str_pointer.read_wstring
         env_list << environment

--- a/mixlib-shellout-universal-mingw32.gemspec
+++ b/mixlib-shellout-universal-mingw32.gemspec
@@ -4,5 +4,6 @@ gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 
 gemspec.add_dependency "win32-process", "~> 0.8.2"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
+gemspec.add_dependency "ffi-win32-extensions", "~> 1.0.3"
 
 gemspec

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -658,6 +658,21 @@ describe Mixlib::ShellOut do
           expect(running_user).to eql("#{ENV["COMPUTERNAME"].downcase}\\#{user}")
         end
 
+        context "when an alternate user is passed" do
+          let(:env_list) { ["ALLUSERSPROFILE=C:\\ProgramData", "TEMP=C:\\Windows\\TEMP", "TMP=C:\\Windows\\TEMP", "USERDOMAIN=WIN-G06ENRTTKF9", "USERNAME=testuser", "USERPROFILE=C:\\Users\\Default", "windir=C:\\Windows"] }
+          let(:current_env) { ["ALLUSERSPROFILE=C:\\ProgramData", "TEMP=C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2", "TMP=C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2", "USER=Administrator", "USERDOMAIN=WIN-G06ENRTTKF9", "USERDOMAIN_ROAMINGPROFILE=WIN-G06ENRTTKF9", "USERNAME=Administrator", "USERPROFILE=C:\\Users\\Administrator", "windir=C:\\Windows"] }
+          let(:merged_env) { ["ALLUSERSPROFILE=C:\\ProgramData", "TEMP=C:\\Windows\\TEMP", "TMP=C:\\Windows\\TEMP", "USER=Administrator", "USERDOMAIN=WIN-G06ENRTTKF9", "USERDOMAIN_ROAMINGPROFILE=WIN-G06ENRTTKF9", "USERNAME=testuser", "USERPROFILE=C:\\Users\\Default", "windir=C:\\Windows"] }
+          let(:converted) { { "ALLUSERSPROFILE" => "C:\\ProgramData", "TEMP" => "C:\\Windows\\TEMP", "TMP" => "C:\\Windows\\TEMP", "USERDOMAIN" => "WIN-G06ENRTTKF9", "USERNAME" => "testuser", "USERPROFILE" => "C:\\Users\\Default", "windir" => "C:\\Windows" } }
+
+          it "merge environment variables" do
+            expect(Process.merge_env_variables(env_list, current_env)).to eql(merged_env)
+          end
+
+          it "Convert an array to a hash" do
+            expect(Process.to_hash(env_list)).to eql(converted)
+          end
+        end
+
         context "when :elevated => true" do
           context "when user and password are passed" do
             let(:options) { { user: user, password: password, elevated: true } }

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -669,7 +669,7 @@ describe Mixlib::ShellOut do
           end
 
           it "Convert an array to a hash" do
-            expect(Process.to_hash(env_list)).to eql(converted)
+            expect(Process.environment_list_to_hash(env_list)).to eql(converted)
           end
         end
 


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

## Description
- Added `CreateEnvironmentBlock` function for fetching environment variables for the specified user.
- Added `DestroyEnvironmentBlock` function for free environment variables after reading, which is created by the `CreateEnvironmentBlock` function

## Related Issue
https://github.com/chef/chef/issues/7690