### PR TITLE
Substitute require for require_relative

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mixlib::ShellOut
-[![Build Status](https://badge.buildkite.com/7051b7b35cc19076c35a6e6a9e996807b0c14475ca3f3acd86.svg)](https://buildkite.com/chef-oss/chef-mixlib-shellout-master-verify) [![Gem Version](https://badge.fury.io/rb/mixlib-shellout.svg)](https://badge.fury.io/rb/mixlib-shellout)
+[![Build Status](https://badge.buildkite.com/7051b7b35cc19076c35a6e6a9e996807b0c14475ca3f3acd86.svg?branch=master)](https://buildkite.com/chef-oss/chef-mixlib-shellout-master-verify) [![Gem Version](https://badge.fury.io/rb/mixlib-shellout.svg)](https://badge.fury.io/rb/mixlib-shellout)
 
 **Umbrella Project**: [Chef Foundation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-foundation.md)
 

--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -19,7 +19,7 @@
 require "etc"
 require "tmpdir"
 require "fcntl"
-require "mixlib/shellout/exceptions"
+require_relative "shellout/exceptions"
 
 module Mixlib
 
@@ -29,10 +29,10 @@ module Mixlib
     DEFAULT_READ_TIMEOUT = 600
 
     if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-      require "mixlib/shellout/windows"
+      require_relative "shellout/windows"
       include ShellOut::Windows
     else
-      require "mixlib/shellout/unix"
+      require_relative "shellout/unix"
       include ShellOut::Unix
     end
 

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -19,7 +19,7 @@
 #
 
 require "win32/process"
-require "mixlib/shellout/windows/core_ext"
+require_relative "windows/core_ext"
 
 module Mixlib
   class ShellOut


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>