### PR TITLE
shellout_spec: make "current user" independent of the environment

### DIFF
--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "etc"
 require "logger"
 require "timeout"
 
@@ -1532,7 +1533,7 @@ describe Mixlib::ShellOut do
 
     context "when no user is set" do
       it "should run as current user" do
-        expect(running_user).to eql(ENV["USER"])
+        expect(running_user).to eql(Etc.getpwuid.name)
       end
     end
 


### PR DESCRIPTION
There is no guarantee that ENV["USER"] is always present, and in some
environments, it's not. Get the current user from Etc.getpwuid, which
works even in the absence of any environment variables.