### PR TITLE
Use a single use box for windows testing to avoid CI failures

### DIFF
--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -1,0 +1,23 @@
+Write-Output "--- system details"
+$Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'
+Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize
+
+$ErrorActionPreference = 'Stop'
+
+Write-Output "--- Enable Ruby 2.7"
+Write-Output "Add Uru to Environment PATH"
+$env:PATH = "C:\Program Files (x86)\Uru;" + $env:PATH
+[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+Write-Output "Register Installed Ruby Version 2.7 With Uru"
+Start-Process "C:\Program Files (x86)\Uru\uru_rt.exe" -ArgumentList 'admin add C:\ruby27\bin' -Wait
+uru 271
+if (-not $?) { throw "Can't Activate Ruby. Did Uru Registration Succeed?" }
+
+Write-Output "+++ bundle install"
+bundle config --local path vendor/bundle
+bundle install --jobs=7 --retry=3
+
+Write-Output "+++ bundle exec rake spec"
+bundle exec rake spec
+if (-not $?) { throw "mixlib-shellout specs failing." }

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -44,10 +44,8 @@ steps:
         image: ruby:2.7-buster
 
 - label: run-specs-windows
-  command:
-    - bundle config --local path vendor/bundle
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
+  commands:
+    - .expeditor/run_windows_tests.ps1
   expeditor:
     executor:
       windows:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -50,5 +50,7 @@ steps:
     - bundle exec rake
   expeditor:
     executor:
-      docker:
-        host_os: windows
+      windows:
+        privileged: true
+        single-use: true
+        shell: ["powershell", "-Command"]


### PR DESCRIPTION
We need to elevate privs on the box and we can't do that in the
container.

Signed-off-by: Tim Smith <tsmith@chef.io>