### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-require "etc"
-require "tmpdir"
+require "etc" unless defined?(Etc)
+require "tmpdir" unless defined?(Dir.mktmpdir)
 require "fcntl"
 require_relative "shellout/exceptions"
 

--- a/lib/mixlib/shellout/helper.rb
+++ b/lib/mixlib/shellout/helper.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 require_relative "../shellout"
-require "chef-utils"
+require "chef-utils" unless defined?(ChefUtils)
 require "chef-utils/dsl/default_paths"
 require "chef-utils/internal"
 


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>