### PR TITLE
Drop the shell_out logging down to trace level

### DIFF
--- a/lib/mixlib/shellout/helper.rb
+++ b/lib/mixlib/shellout/helper.rb
@@ -157,7 +157,7 @@ module Mixlib
       end
 
       def __io_for_live_stream
-        if STDOUT.tty? && !__config[:daemon] && __log.trace?
+        if !STDOUT.closed? && __log.trace?
           STDOUT
         else
           nil

--- a/lib/mixlib/shellout/helper.rb
+++ b/lib/mixlib/shellout/helper.rb
@@ -157,7 +157,7 @@ module Mixlib
       end
 
       def __io_for_live_stream
-        if STDOUT.tty? && !__config[:daemon] && __log.debug?
+        if STDOUT.tty? && !__config[:daemon] && __log.trace?
           STDOUT
         else
           nil

--- a/spec/mixlib/shellout/helper_spec.rb
+++ b/spec/mixlib/shellout/helper_spec.rb
@@ -8,8 +8,9 @@ require "logger"
 #  3. override the __io_for_live_stream method
 #
 class Logger
-  module Severity; TRACE=-1;end
-  def trace(progname = nil, &block);add(TRACE, nil, progname, &block);end
+  module Severity; TRACE = -1; end
+  def trace(progname = nil, &block); add(TRACE, nil, progname, &block); end
+
   def trace?; @level <= TRACE; end
 end
 

--- a/spec/mixlib/shellout/helper_spec.rb
+++ b/spec/mixlib/shellout/helper_spec.rb
@@ -2,6 +2,17 @@ require "spec_helper"
 require "mixlib/shellout/helper"
 require "logger"
 
+# to use this helper you need to either:
+#  1. use mixlib-log which has a trace level
+#  2. monkeypatch a trace level into ruby's logger like this
+#  3. override the __io_for_live_stream method
+#
+class Logger
+  module Severity; TRACE=-1;end
+  def trace(progname = nil, &block);add(TRACE, nil, progname, &block);end
+  def trace?; @level <= TRACE; end
+end
+
 describe Mixlib::ShellOut::Helper, ruby: ">= 2.3" do
   class TestClass
     include Mixlib::ShellOut::Helper


### PR DESCRIPTION
This has to have been an oversight when thom created the trace
level, since live stdout logging produces a lot of output.

We also need this for adding live stdout logging for ohai which
produces a lot of output, where trace is certainly more
appropriate and makes the debug level difficult to read.

