### PR TITLE
Loosen win32-process dep to resolve Ruby 3 deprecation warnings

### DIFF
--- a/mixlib-shellout-universal-mingw32.gemspec
+++ b/mixlib-shellout-universal-mingw32.gemspec
@@ -1,8 +1,8 @@
-gemspec = instance_eval(File.read(File.expand_path("../mixlib-shellout.gemspec", __FILE__)))
+gemspec = instance_eval(File.read(File.expand_path("mixlib-shellout.gemspec", __dir__)))
 
 gemspec.platform = Gem::Platform.new(%w{universal mingw32})
 
-gemspec.add_dependency "win32-process", "~> 0.8.2"
+gemspec.add_dependency "win32-process", "~> 0.9"
 gemspec.add_dependency "wmi-lite", "~> 1.0"
 
 gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-$:.unshift File.expand_path("../lib", __dir__)
-$:.unshift File.expand_path("..", __dir__)
 require "mixlib/shellout"
 
 require "tmpdir"


### PR DESCRIPTION
This removes the use of $SAFE which is causing deprecation warnings when killing processes on Windows.

Signed-off-by: Tim Smith <tsmith@chef.io>