### PR TITLE
fix broken windows tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -52,3 +52,4 @@ steps:
     executor:
       docker:
         host_os: windows
+        user: 'NT AUTHORITY\SYSTEM'


### PR DESCRIPTION
This fixes broken windows tests by:

1. Running docker build as `NT AUTHORITY\SYSTEM` which will have sufficient privileges to impersonate users.
2. Copying `Powershell.exe` instead of `ruby.exe` to a command with a space. Some (likely most) ruby distributions like the one in the buildkite docker image will also need several DLLs copied along with the `exe` in order to work. Powershell does not have that problem.