### PR TITLE
Loosen platform regex to allow 64 or 32 bit mingw

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -28,7 +28,7 @@ module Mixlib
     READ_SIZE = 4096
     DEFAULT_READ_TIMEOUT = 600
 
-    if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    if RUBY_PLATFORM =~ /mswin|mingw|windows/
       require_relative "shellout/windows"
       include ShellOut::Windows
     else


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

Causing test failures on InSpec here (not our only problem) - https://buildkite.com/chef-oss/inspec-inspec-main-verify/builds/4314#4c315e88-e205-42dc-8536-22aae8fef418
 
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #233 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
