### PR TITLE
Add execution time to Windows shellout object

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -60,6 +60,7 @@ module Mixlib
         stderr_read, stderr_write = IO.pipe
         stdin_read, stdin_write = IO.pipe
         open_streams = [ stdout_read, stderr_read ]
+        @execution_time = 0
 
         begin
 
@@ -105,6 +106,8 @@ module Mixlib
               wait_status = WaitForSingleObject(process.process_handle, 0)
               case wait_status
               when WAIT_OBJECT_0
+                # Save the execution time
+                @execution_time = Time.now - start_wait
                 # Get process exit code
                 exit_code = [0].pack("l")
                 unless GetExitCodeProcess(process.process_handle, exit_code)

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -129,6 +129,9 @@ module Mixlib
                   rescue SystemCallError
                     logger&.warn("Failed to kill timed out process #{process.process_id}")
                   end
+                  
+                  # Save the execution time
+                  @execution_time = Time.now - start_wait
 
                   raise Mixlib::ShellOut::CommandTimeout, [
                     "command timed out:",

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -129,7 +129,7 @@ module Mixlib
                   rescue SystemCallError
                     logger&.warn("Failed to kill timed out process #{process.process_id}")
                   end
-                  
+
                   # Save the execution time
                   @execution_time = Time.now - start_wait
 


### PR DESCRIPTION
This adds a missing property (`execution_time`) to Windows.

## Description
Simple change to add an existing property.  Grabs the time when the shell out is complete and compares it to the start of the shell out. 

## Related Issue
#238 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
