### PR TITLE
Keep ffi version below 1.17

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,22 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5
-
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec name: "mixlib-shellout"
 
 gem "win32-process", "~> 0.9"
 gem "ffi-win32-extensions", "~> 1.0.4"
+gem "ffi", "< 1.17.0"
 gem "wmi-lite", "~> 1.0.7"
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,3 @@ group :debug do
   gem "pry-byebug"
   gem "rb-readline"
 end
-
-if Gem.ruby_version < Gem::Version.new("2.6")
-  # 16.7.23 required ruby 2.6+
-  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.4/2.5
-end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
* `ffi` `1.17` and beyond requires a newer RubyGems than is installed with the ruby versions we are using.
* Remove tests for Ruby < 2.7
* Remove Gemfile conditional for Ruby < 2.7

## Related Issue
See also [ffi/ffi#1106](https://github.com/ffi/ffi/issues/1106)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
