### PR TITLE
[tests] Use rspec's ruby executable for run

### DIFF
--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -18,7 +18,7 @@ describe Mixlib::ShellOut do
   let(:ruby_code) { raise "define let(:ruby_code)" }
   let(:options) { nil }
 
-  let(:ruby_eval) { lambda { |code| "ruby -e '#{code}'" } }
+  let(:ruby_eval) { lambda { |code| "#{Gem.ruby} -e '#{code}'" } }
 
   context "when instantiating" do
     subject { shell_cmd }
@@ -1177,7 +1177,7 @@ describe Mixlib::ShellOut do
 
         context "on unix", :unix_only do
           def ruby_wo_shell(code)
-            parts = %w{ruby}
+            parts = [ Gem.ruby ]
             parts << "-e"
             parts << code
           end


### PR DESCRIPTION
## Description

This fixes the assumption that `ruby` is always available from PATH.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
