### PR TITLE
[#239] Add execution time to Windows shellout object

### DIFF
--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -60,6 +60,7 @@ module Mixlib
         stderr_read, stderr_write = IO.pipe
         stdin_read, stdin_write = IO.pipe
         open_streams = [ stdout_read, stderr_read ]
+        @execution_time = 0
 
         begin
 
@@ -105,6 +106,8 @@ module Mixlib
               wait_status = WaitForSingleObject(process.process_handle, 0)
               case wait_status
               when WAIT_OBJECT_0
+                # Save the execution time
+                @execution_time = Time.now - start_wait
                 # Get process exit code
                 exit_code = [0].pack("l")
                 unless GetExitCodeProcess(process.process_handle, exit_code)

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -129,6 +129,9 @@ module Mixlib
                   rescue SystemCallError
                     logger&.warn("Failed to kill timed out process #{process.process_id}")
                   end
+                  
+                  # Save the execution time
+                  @execution_time = Time.now - start_wait
 
                   raise Mixlib::ShellOut::CommandTimeout, [
                     "command timed out:",

--- a/lib/mixlib/shellout/windows.rb
+++ b/lib/mixlib/shellout/windows.rb
@@ -129,7 +129,7 @@ module Mixlib
                   rescue SystemCallError
                     logger&.warn("Failed to kill timed out process #{process.process_id}")
                   end
-                  
+
                   # Save the execution time
                   @execution_time = Time.now - start_wait
 


### PR DESCRIPTION
This is simply a rebased version of #239, as I don't want finished work to hit the floor.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
