### PR TITLE
Fix execution of multiline inputs to target mode; Improve error output

### DIFF
--- a/lib/mixlib/shellout/helper.rb
+++ b/lib/mixlib/shellout/helper.rb
@@ -162,9 +162,9 @@ module Mixlib
             end
 
             if options[:input]
-              args = Array(args)
-              args.concat ["<<<'COMMANDINPUT'\n", options[:input] + "\n", "COMMANDINPUT\n"]
-              logger.debug __join_whitespace(args)
+              command.concat "<<'COMMANDINPUT'\n"
+              command.concat __join_whitespace(options[:input])
+              command.concat "COMMANDINPUT\n"
             end
           end
 
@@ -216,7 +216,7 @@ module Mixlib
         end
 
         def error!
-          raise Mixlib::ShellOut::ShellCommandFailed, "Unexpected exit status of #{exitstatus} running #{@args}" if error?
+          raise Mixlib::ShellOut::ShellCommandFailed, "Unexpected exit status of #{exitstatus} running #{@args}: #{stderr}" if error?
         end
       end
     end


### PR DESCRIPTION
Multiline inputs to Target Mode commands were ignored due to an implementation bug. This is fixed and also, errors will result in the output of `stderr` for debugging purposes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
