### PR TITLE
Fix execution in target mode with cwd parameter given

### DIFF
--- a/lib/mixlib/shellout/helper.rb
+++ b/lib/mixlib/shellout/helper.rb
@@ -158,7 +158,8 @@ module Mixlib
           command = __join_whitespace(args)
           unless ChefUtils.windows?
             if options[:cwd]
-              command.prepend sprintf("cd %s;", options[:cwd])
+              # as `timeout` is used, commands need to be executed in a subshell
+              command = "sh -c 'cd #{options[:cwd]}; #{command}'"
             end
 
             if options[:input]


### PR DESCRIPTION
## Description

This solves a bug when executing commands in Chef Infra Target Mode, when a new working directory is passed with the `cwd` option. Mostly related to the `git`, `freebsd_package`, and `subversion` resources.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
