### PR TITLE
Fix quoting of command arguments in Target Mode

### DIFF
--- a/lib/mixlib/shellout/helper.rb
+++ b/lib/mixlib/shellout/helper.rb
@@ -143,14 +143,17 @@ module Mixlib
 
       # Join arguments into a string.
       #
-      # If the argument ends with a whitespace, use it as-is. Otherwise, add
-      # a space at the end
+      # Strips leading/trailing spaces from each argument. If an argument contains
+      # a space, it is quoted. Join into a single string with spaces between each argument.
       #
       # @param args [String] variable number of string arguments
       # @return [String] merged string
       #
       def __join_whitespace(*args)
-        args.flatten.map { |e| e + (e.rstrip == e ? " " : "") }.join
+        args.flatten.map do |arg|
+          arg.strip!
+          arg.include?(" ") ? sprintf('"%s"', arg) : arg
+        end.join(" ")
       end
 
       def __shell_out_command(*args, **options)


### PR DESCRIPTION
## Description

This fixes the convoluted code to join arguments of a command in Target Mode. This now automatically quotes arguments which contain spaces. Fixes Chef Intra 19.0-rc1 errors on `user` with multi word comments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
