### PR TITLE
Progressive select timeout

### DIFF
--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -18,7 +18,7 @@ describe Mixlib::ShellOut do
   let(:ruby_code) { raise "define let(:ruby_code)" }
   let(:options) { nil }
 
-  let(:ruby_eval) { lambda { |code| "ruby -e '#{code}'" } }
+  let(:ruby_eval) { lambda { |code| "#{Gem.ruby} -e '#{code}'" } }
 
   context "when instantiating" do
     subject { shell_cmd }
@@ -1177,7 +1177,7 @@ describe Mixlib::ShellOut do
 
         context "on unix", :unix_only do
           def ruby_wo_shell(code)
-            parts = %w{ruby}
+            parts = [ Gem.ruby ]
             parts << "-e"
             parts << code
           end

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -18,7 +18,7 @@ describe Mixlib::ShellOut do
   let(:ruby_code) { raise "define let(:ruby_code)" }
   let(:options) { nil }
 
-  let(:ruby_eval) { lambda { |code| "#{Gem.ruby} -e '#{code}'" } }
+  let(:ruby_eval) { lambda { |code| "#{unix? ? Gem.ruby : 'ruby'} -e '#{code}'" } }
 
   context "when instantiating" do
     subject { shell_cmd }


### PR DESCRIPTION
[NOTE] tests are being handled separately in #246, those commits will be gone once this has been rebased

## Description
There doesn't appear to be a reason as to why READ_WAIT_TIME is 10 milliseconds, but that can be an excessive amount of time for quick shellouts. However, syscalls aren't 'free', so simply changing READ_WAIT_TIME to 1 millisecond would increase load where there's   This PR adds a progressive timeout mechanism so that the timeout latency incrementally increases up to READ_WAIT_TIME.
 
## Related Issue
#245 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
