### PR TITLE
Add cgroupv2 support for linux shellouts

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -114,6 +114,9 @@ module Mixlib
 
     attr_accessor :sensitive
 
+    # Path to cgroupv2 that the process should run on
+    attr_accessor :cgroup
+
     # === Arguments:
     # Takes a single command, or a list of command fragments. These are used
     # as arguments to Kernel.exec. See the Kernel.exec documentation for more
@@ -179,6 +182,7 @@ module Mixlib
       @timeout = nil
       @elevated = false
       @sensitive = false
+      @cgroup = nil
 
       if command_args.last.is_a?(Hash)
         parse_options(command_args.pop)
@@ -303,7 +307,8 @@ module Mixlib
     def inspect
       "<#{self.class.name}##{object_id}: command: '#{@command}' process_status: #{@status.inspect} " +
         "stdout: '#{stdout.strip}' stderr: '#{stderr.strip}' child_pid: #{@child_pid.inspect} " +
-        "environment: #{@environment.inspect} timeout: #{timeout} user: #{@user} group: #{@group} working_dir: #{@cwd} >"
+        "environment: #{@environment.inspect} timeout: #{timeout} user: #{@user} group: #{@group} working_dir: #{@cwd} " +
+        "cgroup: #{@cgroup} >"
     end
 
     private
@@ -354,6 +359,8 @@ module Mixlib
           self.elevated = setting
         when "sensitive"
           self.sensitive = setting
+        when "cgroup"
+          self.cgroup = setting
         else
           raise InvalidCommandOption, "option '#{option.inspect}' is not a valid option for #{self.class.name}"
         end

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -317,7 +317,7 @@ module Mixlib
       end
 
       def cgroupv2_available?
-        !File.read("/proc/mounts")[%r{^cgroup2 /sys/fs/cgroup}].nil?
+        File.read("/proc/mounts").match?(%r{^cgroup2 /sys/fs/cgroup})
       end
 
       def fork_subprocess

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -317,7 +317,7 @@ module Mixlib
       end
 
       def cgroupv2_available?
-        !File.read("/proc/mounts")[/^cgroup2/].nil?
+        !File.read("/proc/mounts")[%r{^cgroup2 /sys/fs/cgroup}].nil?
       end
 
       def fork_subprocess

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require 'fileutils'
+require "fileutils" unless defined?(FileUtils)
 
 module Mixlib
   class ShellOut
@@ -317,7 +317,7 @@ module Mixlib
       end
 
       def cgroupv2_available?
-        return !File.read('/proc/mounts')[%r{^cgroup2}].nil?
+        !File.read("/proc/mounts")[/^cgroup2/].nil?
       end
 
       def fork_subprocess

--- a/lib/mixlib/shellout/unix.rb
+++ b/lib/mixlib/shellout/unix.rb
@@ -316,6 +316,10 @@ module Mixlib
         open_pipes.delete(child_process_status)
       end
 
+      def cgroupv2_available?
+        return !File.read('/proc/mounts')[%r{^cgroup2}].nil?
+      end
+
       def fork_subprocess
         initialize_ipc
 
@@ -333,7 +337,7 @@ module Mixlib
 
           configure_subprocess_file_descriptors
 
-          if cgroup
+          if cgroup && cgroupv2_available?
             set_cgroup
           end
 

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -89,6 +89,11 @@ describe Mixlib::ShellOut do
         it { is_expected.to be_nil }
       end
 
+      describe "#cgroup" do
+        subject { super().input }
+        it { is_expected.to be_nil }
+      end
+
       it "should not set any default environmental variables" do
         expect(shell_cmd.environment).to eq({})
       end
@@ -319,6 +324,15 @@ describe Mixlib::ShellOut do
           is_expected.to eql(value)
         end
       end
+
+      context "when setting cgroup" do
+        let(:accessor) { :cgroup }
+        let(:value) { "test" }
+
+        it "should set the cgroup" do
+          is_expected.to eql(value)
+        end
+      end
     end
 
     context "testing login", :unix_only do
@@ -411,7 +425,7 @@ describe Mixlib::ShellOut do
       let(:options) do
         { cwd: cwd, user: user, login: true, domain: domain, password: password, group: group,
           umask: umask, timeout: timeout, environment: environment, returns: valid_exit_codes,
-          live_stream: stream, input: input }
+          live_stream: stream, input: input, cgroup: cgroup }
       end
 
       let(:cwd) { "/tmp" }
@@ -427,6 +441,7 @@ describe Mixlib::ShellOut do
       let(:valid_exit_codes) { [ 0, 1, 42 ] }
       let(:stream) { StringIO.new }
       let(:input) { 1.upto(10).map { "Data #{rand(100000)}" }.join("\n") }
+      let(:cgroup) { "test" }
 
       it "should set the working directory" do
         expect(shell_cmd.cwd).to eql(cwd)
@@ -512,6 +527,10 @@ describe Mixlib::ShellOut do
 
       it "should set the input" do
         expect(shell_cmd.input).to eql(input)
+      end
+
+      it "should set the cgroup" do
+        expect(shell_cmd.cgroup).to eql(cgroup)
       end
 
       context "with an invalid option" do
@@ -1310,6 +1329,7 @@ describe Mixlib::ShellOut do
             end
 
           end
+
         end
       end
 
@@ -1563,6 +1583,28 @@ describe Mixlib::ShellOut do
       it "should run as specified user" do
         expect(running_user).to eql(user.to_s)
       end
+    end
+  end
+
+  context "when running on a cgroup", :linux_only do
+    let(:cmd) { "cat /proc/self/cgroup | cut -c 4-" }
+    let(:options) { { cgroup: cgroup } }
+
+    context "when cgroup exists" do
+      let(:cgroup) { "#{File.read('/proc/self/cgroup')[%r{(/.*)$}, 1]}" }
+      let(:running_cgroup) { shell_cmd.run_command.stdout.chomp }
+      it "should run the process under that cgroup" do
+        expect(running_cgroup).to eql(cgroup.to_s)
+      end
+    end
+
+    context "when cgroup does not exist" do
+      let(:cgroup) { "#{File.read('/proc/self/cgroup')[%r{(/.*)/[^/]+$}, 1]}/test" }
+      let(:running_cgroup) { shell_cmd.run_command.stdout.chomp }
+      it "should create the cgroup and run the process under it" do
+        expect(running_cgroup).to eql(cgroup.to_s)
+        Dir.rmdir("/sys/fs/cgroup/#{cgroup}")
+     end
     end
   end
 end

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1589,7 +1589,7 @@ describe Mixlib::ShellOut do
   context "when running on a cgroup", :linux_only do
     let(:cmd) { "cat /proc/self/cgroup | cut -c 4-" }
     let(:options) { { cgroup: cgroup } }
-    let(:cgroupv2_supported) { !File.read("/proc/mounts")[%r{^cgroup2 /sys/fs/cgroup}].nil? }
+    let(:cgroupv2_supported) { File.read("/proc/mounts").match(%r{^cgroup2 /sys/fs/cgroup}) }
 
     context "when cgroup exists" do
       let(:cgroup) { "#{File.read("/proc/self/cgroup")[%r{(/.*)$}, 1]}" }

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1591,7 +1591,7 @@ describe Mixlib::ShellOut do
     let(:options) { { cgroup: cgroup } }
 
     context "when cgroup exists" do
-      let(:cgroup) { "#{File.read('/proc/self/cgroup')[%r{(/.*)$}, 1]}" }
+      let(:cgroup) { "#{File.read("/proc/self/cgroup")[%r{(/.*)$}, 1]}" }
       let(:running_cgroup) { shell_cmd.run_command.stdout.chomp }
       it "should run the process under that cgroup" do
         expect(running_cgroup).to eql(cgroup.to_s)
@@ -1599,12 +1599,12 @@ describe Mixlib::ShellOut do
     end
 
     context "when cgroup does not exist" do
-      let(:cgroup) { "#{File.read('/proc/self/cgroup')[%r{(/.*)/[^/]+$}, 1]}/test" }
+      let(:cgroup) { "#{File.read("/proc/self/cgroup")[%r{(/.*)/[^/]+$}, 1]}/test" }
       let(:running_cgroup) { shell_cmd.run_command.stdout.chomp }
       it "should create the cgroup and run the process under it" do
         expect(running_cgroup).to eql(cgroup.to_s)
         Dir.rmdir("/sys/fs/cgroup/#{cgroup}")
-     end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   # Add jruby filters here
   config.filter_run_excluding windows_only: true unless windows?
   config.filter_run_excluding unix_only: true unless unix?
+  config.filter_run_excluding linux_only: true unless linux?
   config.filter_run_excluding requires_root: true unless root?
   config.filter_run_excluding ruby: DependencyProc.with(RUBY_VERSION)
 

--- a/spec/support/platform_helpers.rb
+++ b/spec/support/platform_helpers.rb
@@ -6,6 +6,10 @@ def unix?
   !windows?
 end
 
+def linux?
+  !!(RUBY_PLATFORM =~ /linux/)
+end
+
 if windows?
   LINE_ENDING = "\r\n".freeze
   ECHO_LC_ALL = "echo %LC_ALL%".freeze


### PR DESCRIPTION
## Description
This PR aims to implement cgroupv2 support for shellouts, allowing the user to specify under which cgroup should the command be executed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
