### PR TITLE
Drop the FFI pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,12 @@ source "https://rubygems.org"
 gemspec name: "mixlib-shellout"
 
 gem "win32-process", "~> 0.9"
+# for ruby 3.0, install older ffi before
+# installing ffi-requiring stuff
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1")
+  gem "ffi", "< 1.17.0"
+end
 gem "ffi-win32-extensions", "~> 1.0.4"
-gem "ffi", "< 1.17.0"
 gem "wmi-lite", "~> 1.0.7"
 
 group :test do
@@ -15,6 +19,12 @@ end
 
 group :debug do
   gem "pry"
+  # version lock for old ruby 3.0 - once we're off
+  # of 3.0, remove this line, let pry-byebug pull
+  # in whatever it wants
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1")
+    gem "byebug", "~> 11.1"
+  end
   gem "pry-byebug"
   gem "rb-readline"
 end

--- a/mixlib-shellout.gemspec
+++ b/mixlib-shellout.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/mixlib-shellout"
   s.license = "Apache-2.0"
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "chef-utils"
   s.require_path = "lib"


### PR DESCRIPTION
* Kept ffi pin for older ruby's since that's required.
* Did not use `install_if`, as it seems quite buggy still
* Bumped the min ruby as it was ancient.


Signed-off-by: Phil Dibowitz <phil@ipom.com>
