### PR TITLE
assign @stdout, @stderr and @process_status to mutable strings in preparation for ruby 4.0

### DIFF
--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -170,7 +170,7 @@ module Mixlib
     #   cmd = Mixlib::ShellOut.new("apachectl", "start", :user => 'www', :env => nil, :cwd => '/tmp')
     #   cmd.run_command # etc.
     def initialize(*command_args)
-      @stdout, @stderr, @process_status = "", "", ""
+      @stdout, @stderr, @process_status = String.new(""), String.new(""), String.new("")
       @live_stdout = @live_stderr = nil
       @input = nil
       @log_level = :debug

--- a/lib/mixlib/shellout.rb
+++ b/lib/mixlib/shellout.rb
@@ -170,6 +170,7 @@ module Mixlib
     #   cmd = Mixlib::ShellOut.new("apachectl", "start", :user => 'www', :env => nil, :cwd => '/tmp')
     #   cmd.run_command # etc.
     def initialize(*command_args)
+      # Since ruby 4.0 will freeze string literals by default, we are assigning mutable strings here.
       @stdout, @stderr, @process_status = String.new(""), String.new(""), String.new("")
       @live_stdout = @live_stderr = nil
       @input = nil

--- a/lib/mixlib/shellout/windows/core_ext.rb
+++ b/lib/mixlib/shellout/windows/core_ext.rb
@@ -447,7 +447,6 @@ module Process
 
     def create_process_as_user(token, app, cmd, process_security,
       thread_security, inherit, creation_flags, env, cwd, startinfo, procinfo)
-
       bool = CreateProcessAsUserW(
         token,            # User token handle
         app,              # App name
@@ -479,7 +478,6 @@ module Process
 
     def create_process_with_logon(logon, domain, passwd, logon_flags, app, cmd,
       creation_flags, env, cwd, startinfo, procinfo)
-
       bool = CreateProcessWithLogonW(
         logon,           # User
         domain,          # Domain
@@ -501,7 +499,6 @@ module Process
 
     def create_process(app, cmd, process_security, thread_security, inherit,
       creation_flags, env, cwd, startinfo, procinfo)
-
       bool = CreateProcessW(
         app,               # App name
         cmd,               # Command line

--- a/spec/mixlib/shellout_spec.rb
+++ b/spec/mixlib/shellout_spec.rb
@@ -1613,4 +1613,3 @@ describe Mixlib::ShellOut do
     end
   end
 end
-


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
updating the initalisation because of ruby 3.4 warnings since ruby 4.0 is going to freeze strings by default. 

related issue: #257 

JIRA: https://progresssoftware.atlassian.net/browse/CHEF-20948

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
