### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,3 @@
 
 *                 @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners @jaymzh
 .expeditor/       @chef/infra-packages
-*.md              @chef/docs-team


### PR DESCRIPTION
Dropping docs-team requirement like with other repos.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
